### PR TITLE
<FillUp /> with 100% width and height by default

### DIFF
--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -1,0 +1,10 @@
+/*
+  these properties can be unset, but in most
+  cases you want the ember-fill-up component
+  to fill its container. The layout or
+  container should provide the constraints.
+*/
+.ember-fill-up {
+  width: 100%;
+  height: 100%;
+}

--- a/addon/templates/components/fill-up.hbs
+++ b/addon/templates/components/fill-up.hbs
@@ -1,5 +1,7 @@
-<div class={{concat "ember-fill-up" " " this.classNames " " breakpointClassNames}}
-  {{fill-up onChange=(action this.onElementChange)}} ...attributes>
+<div class={{concat "ember-fill-up" " " this.classNames}}
+  {{fill-up onChange=(action this.onElementChange)}}
+  ...attributes
+>
   {{yield (hash
     width=this.width
     height=this.height


### PR DESCRIPTION
In almost all cases what is wanted is for `<FillUp/>` to absolutely fill as much space in the layout as possible, so the component will ship with a width and height of 100%. In the rare cases, these properties could be unset with an overriding CSS selector.