### PR TITLE
Add height dimension to breakpoint definitions

### DIFF
--- a/addon/components/fill-up.js
+++ b/addon/components/fill-up.js
@@ -26,25 +26,38 @@ export default Component.extend({
       this.set('width', width);
       this.set('height', height);
 
-      this.onChange({
-        element: this.fillUpElement,
-        width: this.width,
-        height: this.height,
-        breakpoints: this.breakpointsMap
-      });
+      this.triggerOnChangeHandler();
+      this.handleBreakpointChanges();
+    }
+  },
 
-      if (this.breakpoints) {
-        const map = definitionsMap(this.width, this.breakpoints);
+  triggerOnChangeHandler() {
+    if (typeof this.onChange !== 'function') {
+      return;
+    }
 
-        this.set('breakpointsMap', map);
+    this.onChange({
+      element: this.fillUpElement,
+      width: this.width,
+      height: this.height,
+      breakpoints: this.breakpointsMap
+    });
+  },
 
-        for (const key in map) {
-          const breakpointIsSet = map[key];
-          if (breakpointIsSet) {
-            element.setAttribute(this.attributePrefix + key, '');
-          } else {
-            element.removeAttribute(this.attributePrefix + key);
-          }
+  handleBreakpointChanges() {
+    if (this.breakpoints) {
+      const dimensions = { width: this.width, height: this.height };
+      const map = definitionsMap(dimensions, this.breakpoints);
+
+      this.set('breakpointsMap', map);
+
+      // make changes to element
+      for (const key in map) {
+        const breakpointIsSet = map[key];
+        if (breakpointIsSet) {
+          this.fillUpElement.setAttribute(this.attributePrefix + key, '');
+        } else {
+          this.fillUpElement.removeAttribute(this.attributePrefix + key);
         }
       }
     }

--- a/addon/definitions.js
+++ b/addon/definitions.js
@@ -1,3 +1,5 @@
+import { assert } from '@ember/debug';
+
 import {
   lt as _lt,
   lte as _lte,
@@ -7,39 +9,52 @@ import {
   betweenRightClosed
 } from './utils';
 
-function buildDefinition(comparisonFunction) {
+function buildDefinition(comparisonFunction, dimension = 'width') {
+  dimension = typeof dimension === 'string' ? dimension.toLowerCase() : dimension;
+
+  assert(
+    `Breakpoint definition dimensions must be a string defined as 'width' or 'height', received ${dimension}`,
+    dimension === 'width' || dimension === 'height'
+  );
+
   return {
-    comparison: comparisonFunction
+    comparison: comparisonFunction,
+    dimension
   };
 }
 
-export function lt(definedValue) {
-  return buildDefinition(value => _lt(value, definedValue));
+export function lt(definedValue, { dimension } = {}) {
+  return buildDefinition(value => _lt(value, definedValue), dimension);
 }
 
-export function lte(definedValue) {
-  return buildDefinition(value => _lte(value, definedValue));
+export function lte(definedValue, { dimension } = {}) {
+  return buildDefinition(value => _lte(value, definedValue), dimension);
 }
 
-export function gt(definedValue) {
-  return buildDefinition(value => _gt(value, definedValue));
+export function gt(definedValue, { dimension } = {}) {
+  return buildDefinition(value => _gt(value, definedValue), dimension);
 }
 
-export function gte(definedValue) {
-  return buildDefinition(value => _gte(value, definedValue));
+export function gte(definedValue, { dimension } = {}) {
+  return buildDefinition(value => _gte(value, definedValue), dimension);
 }
 
-export function eq(definedValue) {
-  return buildDefinition(value => _eq(value, definedValue));
+export function eq(definedValue, { dimension } = {}) {
+  return buildDefinition(value => _eq(value, definedValue), dimension);
 }
 
-export function between(firstDefined, secondDefined) {
-  return buildDefinition(value => betweenRightClosed(value, firstDefined, secondDefined));
+export function between(firstDefined, secondDefined, { dimension } = {}) {
+  return buildDefinition(
+    value => betweenRightClosed(value, firstDefined, secondDefined),
+    dimension
+  );
 }
 
-export function definitionsMap(currentValue, definitions) {
+export function definitionsMap({ width, height }, definitions) {
   return Object.keys(definitions).reduce((map, breakpointLabel) => {
-    const { comparison } = definitions[breakpointLabel];
+    const { comparison, dimension } = definitions[breakpointLabel];
+    const currentValue = dimension === 'width' ? width : height || 0;
+
     return {
       ...map,
       [breakpointLabel]: comparison(currentValue)

--- a/addon/helpers/fill-up-between.js
+++ b/addon/helpers/fill-up-between.js
@@ -1,8 +1,8 @@
 import { helper } from '@ember/component/helper';
 import { between } from 'ember-fill-up/definitions';
 
-export function fillUpBetween([leftBound, rightBound]) {
-  return between(leftBound, rightBound);
+export function fillUpBetween([leftBound, rightBound], { dimension } = {}) {
+  return between(leftBound, rightBound, { dimension });
 }
 
 export default helper(fillUpBetween);

--- a/addon/helpers/fill-up-eq.js
+++ b/addon/helpers/fill-up-eq.js
@@ -1,8 +1,8 @@
 import { helper } from '@ember/component/helper';
 import { eq } from 'ember-fill-up/definitions';
 
-export function fillUpEq([value]) {
-  return eq(value);
+export function fillUpEq([value], { dimension } = {}) {
+  return eq(value, { dimension });
 }
 
 export default helper(fillUpEq);

--- a/addon/helpers/fill-up-gt.js
+++ b/addon/helpers/fill-up-gt.js
@@ -1,8 +1,8 @@
 import { helper } from '@ember/component/helper';
 import { gt } from 'ember-fill-up/definitions';
 
-export function fillUpGt([value]) {
-  return gt(value);
+export function fillUpGt([value], { dimension } = {}) {
+  return gt(value, { dimension });
 }
 
 export default helper(fillUpGt);

--- a/addon/helpers/fill-up-gte.js
+++ b/addon/helpers/fill-up-gte.js
@@ -1,8 +1,8 @@
 import { helper } from '@ember/component/helper';
 import { gte } from 'ember-fill-up/definitions';
 
-export function fillUpGte([value]) {
-  return gte(value);
+export function fillUpGte([value], { dimension } = {}) {
+  return gte(value, { dimension });
 }
 
 export default helper(fillUpGte);

--- a/addon/helpers/fill-up-lt.js
+++ b/addon/helpers/fill-up-lt.js
@@ -1,8 +1,8 @@
 import { helper } from '@ember/component/helper';
 import { lt } from 'ember-fill-up/definitions';
 
-export function fillUpLt([value]) {
-  return lt(value);
+export function fillUpLt([value], { dimension } = {}) {
+  return lt(value, { dimension });
 }
 
 export default helper(fillUpLt);

--- a/addon/helpers/fill-up-lte.js
+++ b/addon/helpers/fill-up-lte.js
@@ -1,8 +1,8 @@
 import { helper } from '@ember/component/helper';
 import { lte } from 'ember-fill-up/definitions';
 
-export function fillUpLte([value]) {
-  return lte(value);
+export function fillUpLte([value], { dimension } = {}) {
+  return lte(value, { dimension });
 }
 
 export default helper(fillUpLte);

--- a/tests/dummy/app/components/volume.js
+++ b/tests/dummy/app/components/volume.js
@@ -1,0 +1,8 @@
+import Component from '@ember/component';
+import layout from '../templates/components/volume';
+
+export default Component.extend({
+  layout,
+
+  tagName: ''
+});

--- a/tests/dummy/app/components/weather.js
+++ b/tests/dummy/app/components/weather.js
@@ -58,6 +58,7 @@ export default Component.extend({
 
     const city = faker.random.arrayElement(cities);
     this.set('city', city);
+
     // remove city from the array so it's not reused
     cities.splice(cities.indexOf(city), 1);
 
@@ -77,5 +78,10 @@ export default Component.extend({
       const fontSize = Math.min(Number(width) / 12, 65);
       this.set('fontSize', fontSize);
     }
+  },
+
+  willDestroy() {
+    // put the city back so we don't run out of cities
+    cities.push(this.city);
   }
 });

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -49,6 +49,36 @@ body {
 
 /* components */
 
+/* volume */
+.volume {
+  width: 150px;
+  border: 1px solid black;
+  display: flex;
+  align-items: center;
+  justify-items: center;
+  text-align: center;
+  min-height: 3rem;
+}
+
+.volume[fill-up-off] {
+  font-size: 3rem;
+  background-color: #00044F;
+}
+
+.volume[fill-up-quiet] {
+  font-size: 5rem;
+  background-color: #00077F;
+}
+
+.volume[fill-up-loud] {
+ font-size: 8rem;
+ background-color: #000AAF;
+}
+
+.volume[fill-up-loudest] {
+ font-size: 13rem;
+ background-color: #000FFF;
+}
 /* github card */
 .github-card {
   width: 100%;

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -43,6 +43,10 @@ body {
   width: 250px;
 }
 
+.resize-area.vertical {
+  resize: vertical;
+}
+
 .resize-area > * {
   margin: auto;
 }
@@ -79,6 +83,16 @@ body {
  font-size: 13rem;
  background-color: #000FFF;
 }
+
+.demo-volume-bottom-margin {
+  margin-bottom: 400px;
+}
+
+.demo-volume-bottom-margin > .resize-area {
+  height: 100px;
+  min-height: 100px;
+}
+
 /* github card */
 .github-card {
   width: 100%;

--- a/tests/dummy/app/templates/components/volume.hbs
+++ b/tests/dummy/app/templates/components/volume.hbs
@@ -1,0 +1,19 @@
+<FillUp
+  class="volume demo-bottom-margin"
+  @breakpoints={{hash
+    off=(fill-up-between 0 151 dimension="height")
+    quiet=(fill-up-between 151 300 dimension="height")
+    loud=(fill-up-between 300 450 dimension="height")
+    loudest=(fill-up-gte 450 dimension="height")
+  }}
+as |F|>
+  {{#if F.breakpoints.off}}
+    🔇
+  {{else if F.breakpoints.quiet}}
+    🔈
+  {{else if F.breakpoints.loud}}
+    🔉
+  {{else if F.breakpoints.loudest}}
+    🔊
+  {{/if}}
+</FillUp>

--- a/tests/dummy/app/templates/single.hbs
+++ b/tests/dummy/app/templates/single.hbs
@@ -9,3 +9,9 @@
 <div class="resize-area">
   <Article />
 </div>
+
+<div class="demo-volume-bottom-margin">
+  <div class="resize-area vertical">
+    <Volume/>
+  </div>
+</div>

--- a/tests/unit/definitions-test.js
+++ b/tests/unit/definitions-test.js
@@ -2,72 +2,154 @@ import { module, test } from 'qunit';
 import { lt, lte, gt, gte, eq, between, definitionsMap } from 'ember-fill-up/definitions';
 
 module('Unit | definitions', function() {
-  test('lt definition', function(assert) {
-    let definition = lt(400);
+  module('comparisons', function() {
+    test('lt definition', function(assert) {
+      let definition = lt(400);
 
-    assert.equal(definition.comparison(500), false);
-    assert.equal(definition.comparison(400), false);
-    assert.equal(definition.comparison(300), true);
-  });
-
-  test('lte definition', function(assert) {
-    let definition = lte(400);
-
-    assert.equal(definition.comparison(500), false);
-    assert.equal(definition.comparison(400), true);
-    assert.equal(definition.comparison(300), true);
-  });
-
-  test('gt definition', function(assert) {
-    let definition = gt(400);
-
-    assert.equal(definition.comparison(500), true);
-    assert.equal(definition.comparison(400), false);
-    assert.equal(definition.comparison(300), false);
-  });
-
-  test('gte definition', function(assert) {
-    let definition = gte(400);
-
-    assert.equal(definition.comparison(500), true);
-    assert.equal(definition.comparison(400), true);
-    assert.equal(definition.comparison(300), false);
-  });
-
-  test('eq definition', function(assert) {
-    let definition = eq(400);
-
-    assert.equal(definition.comparison(500), false);
-    assert.equal(definition.comparison(400), true);
-    assert.equal(definition.comparison(300), false);
-  });
-
-  test('between definition', function(assert) {
-    let definition = between(400, 600);
-
-    assert.equal(definition.comparison(700), false);
-    assert.equal(definition.comparison(600), false, 'upper bound is not included');
-    assert.equal(definition.comparison(500), true);
-    assert.equal(definition.comparison(400), true, 'lower bound is included');
-    assert.equal(definition.comparison(300), false);
-  });
-
-  test('it creates a definitions map from an array of definitions', function(assert) {
-    let definitions = {
-      'truthy-equal': eq(400),
-      'truthy-less-than': lt(800),
-      'falsy-less-than': lt(0),
-      'truthy-greater-than': gt(200)
-    };
-
-    let currentValue = 400;
-    let result = definitionsMap(currentValue, definitions);
-
-    assert.deepEqual(result, {
-      'truthy-equal': true,
-      'truthy-less-than': true,
-      'truthy-greater-than': true,
-      'falsy-less-than': false
+      assert.equal(definition.comparison(500), false);
+      assert.equal(definition.comparison(400), false);
+      assert.equal(definition.comparison(300), true);
     });
+
+    test('lte definition', function(assert) {
+      let definition = lte(400);
+
+      assert.equal(definition.comparison(500), false);
+      assert.equal(definition.comparison(400), true);
+      assert.equal(definition.comparison(300), true);
+    });
+
+    test('gt definition', function(assert) {
+      let definition = gt(400);
+
+      assert.equal(definition.comparison(500), true);
+      assert.equal(definition.comparison(400), false);
+      assert.equal(definition.comparison(300), false);
+    });
+
+    test('gte definition', function(assert) {
+      let definition = gte(400);
+
+      assert.equal(definition.comparison(500), true);
+      assert.equal(definition.comparison(400), true);
+      assert.equal(definition.comparison(300), false);
+    });
+
+    test('eq definition', function(assert) {
+      let definition = eq(400);
+
+      assert.equal(definition.comparison(500), false);
+      assert.equal(definition.comparison(400), true);
+      assert.equal(definition.comparison(300), false);
+    });
+
+    test('between definition', function(assert) {
+      let definition = between(400, 600);
+
+      assert.equal(definition.comparison(700), false);
+      assert.equal(definition.comparison(600), false, 'upper bound is not included');
+      assert.equal(definition.comparison(500), true);
+      assert.equal(definition.comparison(400), true, 'lower bound is included');
+      assert.equal(definition.comparison(300), false);
+    });
+
+    test('it creates a definitions map from a hash of definitions', function(assert) {
+      let definitions = {
+        'truthy-equal': eq(400),
+        'truthy-less-than': lt(800),
+        'falsy-less-than': lt(0),
+        'truthy-greater-than': gt(200)
+      };
+
+      let currentValue = 400;
+      let result = definitionsMap({ width: currentValue }, definitions);
+
+      assert.deepEqual(result, {
+        'truthy-equal': true,
+        'truthy-less-than': true,
+        'truthy-greater-than': true,
+        'falsy-less-than': false
+      });
+    });
+  });
+
+  test('it by default saves the width dimension on the definition', function(assert) {
+    const ltDefinition = lt(5);
+    const lteDefinition = lte(5);
+    const gtDefinition = gt(5);
+    const gteDefinition = gte(5);
+    const eqDefinition = eq(5);
+    const betweenDefinition = between(5, 10);
+
+    assert.equal(ltDefinition.dimension, 'width');
+    assert.equal(lteDefinition.dimension, 'width');
+    assert.equal(gtDefinition.dimension, 'width');
+    assert.equal(gteDefinition.dimension, 'width');
+    assert.equal(eqDefinition.dimension, 'width');
+    assert.equal(betweenDefinition.dimension, 'width');
+  });
+
+  test('it saves the width dimension on the dimension', function(assert) {
+    const ltDefinition = lt(5, { dimension: 'width' });
+    const lteDefinition = lte(5, { dimension: 'width' });
+    const gtDefinition = gt(5, { dimension: 'width' });
+    const gteDefinition = gte(5, { dimension: 'width' });
+    const eqDefinition = eq(5, { dimension: 'width' });
+    const betweenDefinition = between(5, 10, { dimension: 'width' });
+
+    assert.equal(ltDefinition.dimension, 'width');
+    assert.equal(lteDefinition.dimension, 'width');
+    assert.equal(gtDefinition.dimension, 'width');
+    assert.equal(gteDefinition.dimension, 'width');
+    assert.equal(eqDefinition.dimension, 'width');
+    assert.equal(betweenDefinition.dimension, 'width');
+  });
+
+  test('it saves the height dimension on the dimension', function(assert) {
+    const ltDefinition = lt(5, { dimension: 'height' });
+    const lteDefinition = lte(5, { dimension: 'height' });
+    const gtDefinition = gt(5, { dimension: 'height' });
+    const gteDefinition = gte(5, { dimension: 'height' });
+    const eqDefinition = eq(5, { dimension: 'height' });
+    const betweenDefinition = between(5, 10, { dimension: 'height' });
+
+    assert.equal(ltDefinition.dimension, 'height');
+    assert.equal(lteDefinition.dimension, 'height');
+    assert.equal(gtDefinition.dimension, 'height');
+    assert.equal(gteDefinition.dimension, 'height');
+    assert.equal(eqDefinition.dimension, 'height');
+    assert.equal(betweenDefinition.dimension, 'height');
+  });
+
+  test('it throws when a value that is not width or height is given for the dimension', function(assert) {
+    assert.throws(
+      () => lt(5, { dimension: 'not-a-dimension' }),
+      'lt throws when passed something that is not a dimension'
+    );
+
+    assert.throws(
+      () => lte(5, { dimension: 'not-a-dimension' }),
+      'lte throws when passed something that is not a dimension'
+    );
+
+    assert.throws(
+      () => gt(5, { dimension: 'not-a-dimension' }),
+      'gt throws when passed something that is not a dimension'
+    );
+
+    assert.throws(
+      () => gte(5, { dimension: 'not-a-dimension' }),
+      'gte throws when passed something that is not a dimension'
+    );
+
+    assert.throws(
+      () => eq(5, { dimension: 'not-a-dimension' }),
+      'eq throws when passed something that is not a dimension'
+    );
+
+    assert.throws(
+      () => between(5, 10, { dimension: 'not-a-dimension' }),
+      'between throws when passed something that is not a dimension'
+    );
   });
 });


### PR DESCRIPTION
This pull request allows for a dimension to be defined along with a breakpoint definition. By default, the width dimension will be used, but `width` or `height` string values can be passed and comparisons will be mapped to changes with the corresponding dimension.

As an example, see the volume component on the `/single` route.