### PR TITLE
Disable CI dummy app deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,15 @@ branches:
     # npm version tags
     - /^v\d+\.\d+\.\d+/
 
-deploy:
-  provider: pages
-  skip-cleanup: true
-  github-token: $GITHUB_TOKEN
-  keep-history: true
-  on:
-    branch: master
-  local-dir: dist
-  verbose: true
+# deploy:
+#   provider: pages
+#   skip-cleanup: true
+#   github-token: $GITHUB_TOKEN
+#   keep-history: true
+#   on:
+#     branch: master
+#   local-dir: dist
+#   verbose: true
 
 jobs:
   fail_fast: true


### PR DESCRIPTION
Although the test suite is passing the CI dummy app is not currently deploying correctly upon merging to master properly. For now the CI deploy will be disabled and the deploys to github pages will be done locally.